### PR TITLE
Add mode where multiple shifts of the same course/type can be selected

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -237,8 +237,8 @@ class App extends React.Component <{
 		if (chosenShift) {
 			const shiftCourse = this.state.selectedCourses.courses.filter((c) => c.id === chosenShift.courseId)
 
-			const idx
-			const replacingIndex
+			let idx
+			let replacingIndex
 			if (this.state.multiShiftMode) {
 				// We want to allow multiple shifts of the same type, don't replace anything
 				idx = -1

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -75,6 +75,7 @@ class App extends React.Component <{
 		loading: true as boolean,
 		lang: i18next.options.lng as string,
 		darkMode: false,
+		multiShiftMode: false,
 		colorPicker: { show: false as boolean, course: undefined as (undefined | Course)  }
 	}
 	savedStateHandler: SavedStateHandler
@@ -236,12 +237,20 @@ class App extends React.Component <{
 		if (chosenShift) {
 			const shiftCourse = this.state.selectedCourses.courses.filter((c) => c.id === chosenShift.courseId)
 
-			// Verify if of the same type and course to replace, but not the same
-			const replacingIndex = Comparables.indexOfBy(this.state.selectedShifts, chosenShift, Shift.isSameCourseAndType)
-			const selectedShifts = this.state.selectedShifts
-			
-			// Verify if shift is already selected and unselect
-			const idx = Comparables.indexOf(selectedShifts, chosenShift)
+			const idx
+			const replacingIndex
+			if (this.state.multiShiftMode) {
+				// We want to allow multiple shifts of the same type, don't replace anything
+				idx = -1
+			} else {
+				// Verify if of the same type and course to replace, but not the same
+				replacingIndex = Comparables.indexOfBy(this.state.selectedShifts, chosenShift, Shift.isSameCourseAndType)
+				const selectedShifts = this.state.selectedShifts
+
+				// Verify if shift is already selected and unselect
+				idx = Comparables.indexOf(selectedShifts, chosenShift)
+			}
+
 			if (idx === -1) {
 				selectedShifts.push(chosenShift)
 				if (replacingIndex !== -1) {
@@ -257,6 +266,13 @@ class App extends React.Component <{
 			}
 
 			this.setSelectedShifts(selectedShifts)
+		}
+	}
+
+	onChangeMultiShiftMode(multiShiftMode: boolean): void {
+		if (!multiShiftMode) {
+			// TODO: prevent multiShiftMode from being disabled when the current
+			// schedule is impossible to build without it
 		}
 	}
 
@@ -500,6 +516,8 @@ class App extends React.Component <{
 						onChangeLanguage={this.changeLanguage}
 						darkMode={this.state.darkMode}
 						onChangeDarkMode={this.onChangeDarkMode}
+						multiShiftMode={this.state.multiShiftMode}
+						onChangeMultiShiftMode={this.onChangeMultiShiftMode}
 					>
 					</TopBar>
 					<div className="main">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,6 +33,8 @@ import CardContent from '@material-ui/core/CardContent'
 import CardActions from '@material-ui/core/CardActions'
 import Chip from '@material-ui/core/Chip'
 import Paper from '@material-ui/core/Paper'
+import Switch from '@material-ui/core/Switch'
+import FormControlLabel from '@material-ui/core/FormControlLabel'
 import ToggleButton from '@material-ui/lab/ToggleButton'
 import ToggleButtonGroup from '@material-ui/lab/ToggleButtonGroup'
 import Backdrop from '@material-ui/core/Backdrop'
@@ -57,6 +59,8 @@ import DialogContent from '@material-ui/core/DialogContent'
 import Box from '@material-ui/core/Box'
 import { APP_STYLES } from './styles/styles'
 
+import AllInclusiveIcon from '@material-ui/icons/AllInclusive'
+
 class App extends React.Component <{
 	classes: CreateCSSProperties
 }>{
@@ -77,7 +81,7 @@ class App extends React.Component <{
 		lang: i18next.options.lng as string,
 		darkMode: false,
 		multiShiftMode: false,
-		disableMultiShiftModeChange: false,
+		inhibitMultiShiftModeChange: false,
 		colorPicker: { show: false as boolean, course: undefined as (undefined | Course)  }
 	}
 	savedStateHandler: SavedStateHandler
@@ -244,7 +248,7 @@ class App extends React.Component <{
 			([a, b]) => Shift.isSameCourseAndType(a,b)
 		)
 
-		this.setState({ disableMultiShiftModeChange: disable })
+		this.setState({ inhibitMultiShiftModeChange: disable })
 	}
 
 	onSelectedShift(shiftName: string, arr: Shift[]): void {
@@ -270,7 +274,7 @@ class App extends React.Component <{
 			if (idx === -1) {
 				selectedShifts.push(chosenShift)
 				if (replacingIndex !== -1) {
-					selectedShifts.splice(replacingIndex, 1)  
+					selectedShifts.splice(replacingIndex, 1)
 				} else if (shiftCourse.length === 1) {
 					shiftCourse[0].addSelectedShift(chosenShift)
 				}
@@ -285,10 +289,10 @@ class App extends React.Component <{
 		}
 	}
 
-	onChangeMultiShiftMode(multiShiftMode: boolean): void {
-		this.savedStateHandler.setMultiShiftMode(multiShiftMode)
+	onChangeMultiShiftMode(event: React.ChangeEvent<HTMLInputElement>, value: boolean): void {
+		this.savedStateHandler.setMultiShiftMode(value)
 		this.setState({
-			multiShiftMode: multiShiftMode
+			multiShiftMode: value
 		})
 	}
 
@@ -544,9 +548,6 @@ class App extends React.Component <{
 						onChangeLanguage={this.changeLanguage}
 						darkMode={this.state.darkMode}
 						onChangeDarkMode={this.onChangeDarkMode}
-						multiShiftMode={this.state.multiShiftMode}
-						disableMultiShiftModeChange={this.state.disableMultiShiftModeChange}
-						onChangeMultiShiftMode={this.onChangeMultiShiftMode}
 					>
 					</TopBar>
 					<div className="main">
@@ -599,7 +600,7 @@ class App extends React.Component <{
 											>
 												{Object.entries(ShiftType).map((name) => (
 													<ToggleButton key={name[1]} value={name[1]}>{name[0]}</ToggleButton>
-												))}       
+												))}
 											</StyledToggleButtonGroup>
 										</Paper>
 									</CardActions>
@@ -687,6 +688,22 @@ class App extends React.Component <{
 													<Icon>delete</Icon>
 												</IconButton>
 											</Tooltip>
+											<Tooltip title={i18next.t('multishiftmode-switch') as string}>
+												{/* pay no attention to the dirty styling hacks */}
+												<FormControlLabel
+													label={<AllInclusiveIcon style={{marginBottom: '-7px'}} />}
+													labelPlacement="top"
+													control={
+														<Switch
+															checked={this.state.multiShiftMode}
+															disabled={this.state.inhibitMultiShiftModeChange}
+															onChange={this.onChangeMultiShiftMode}
+															size="small"
+														/>
+													}
+													style={{margin: '0 6px'}}
+												/>
+											</Tooltip>
 										</div>
 									</CardActions>
 								</Card>
@@ -735,7 +752,7 @@ class App extends React.Component <{
 										</IconButton>
 									</Link>
 								</Tooltip>
-							</Toolbar>													
+							</Toolbar>
 						</AppBar>
 					</div>
 					<div className="dialogs">
@@ -772,7 +789,7 @@ class App extends React.Component <{
 								<Button onClick={() => {this.warningContinue(); this.setState({warningDialog: false})}} color="primary">{i18next.t('warning.actions.continue') as string}</Button>
 								{/* <Button onClick={() => {this.setState({warningDialog: false})}} color="primary">{i18next.t('warning.actions.back') as string}</Button> */}
 							</DialogActions>
-						</Dialog>	
+						</Dialog>
 						<Dialog open={this.state.changelogDialog}>
 							<DialogTitle>{i18next.t('changelog-dialog.title') as string}</DialogTitle>
 							<DialogContent style={{whiteSpace: 'pre-line'}}>{(i18next.t('changelog-dialog.content', {returnObjects: true}) as string[]).join('\n\n')}</DialogContent>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -104,6 +104,7 @@ class App extends React.Component <{
 		this.showAlert = this.showAlert.bind(this)
 		this.changeLanguage = this.changeLanguage.bind(this)
 		this.onChangeDarkMode = this.onChangeDarkMode.bind(this)
+		this.onChangeMultiShiftMode = this.onChangeMultiShiftMode.bind(this)
 		this.exportToExcel = this.exportToExcel.bind(this)
 
 		this.chosenSchedule = React.createRef()
@@ -237,18 +238,18 @@ class App extends React.Component <{
 		if (chosenShift) {
 			const shiftCourse = this.state.selectedCourses.courses.filter((c) => c.id === chosenShift.courseId)
 
-			let idx
+			const selectedShifts = this.state.selectedShifts
+
+			// Verify if shift is already selected and unselect
+			const idx = Comparables.indexOf(selectedShifts, chosenShift)
+
 			let replacingIndex
 			if (this.state.multiShiftMode) {
 				// We want to allow multiple shifts of the same type, don't replace anything
-				idx = -1
+				replacingIndex = -1
 			} else {
 				// Verify if of the same type and course to replace, but not the same
 				replacingIndex = Comparables.indexOfBy(this.state.selectedShifts, chosenShift, Shift.isSameCourseAndType)
-				const selectedShifts = this.state.selectedShifts
-
-				// Verify if shift is already selected and unselect
-				idx = Comparables.indexOf(selectedShifts, chosenShift)
 			}
 
 			if (idx === -1) {
@@ -270,10 +271,9 @@ class App extends React.Component <{
 	}
 
 	onChangeMultiShiftMode(multiShiftMode: boolean): void {
-		if (!multiShiftMode) {
-			// TODO: prevent multiShiftMode from being disabled when the current
-			// schedule is impossible to build without it
-		}
+		this.setState({
+			multiShiftMode: multiShiftMode
+		})
 	}
 
 	clearSelectedShifts(alert: boolean): void {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import Degree from './domain/Degree'
 
 import saveToExcel from './utils/excel'
 import getCalendar from './utils/calendar-generator'
+import { combinations2, it_contains } from './utils/itertools'
 
 import i18next from 'i18next'
 import withStyles, { CreateCSSProperties } from '@material-ui/core/styles/withStyles'
@@ -76,6 +77,7 @@ class App extends React.Component <{
 		lang: i18next.options.lng as string,
 		darkMode: false,
 		multiShiftMode: false,
+		disableMultiShiftModeChange: false,
 		colorPicker: { show: false as boolean, course: undefined as (undefined | Course)  }
 	}
 	savedStateHandler: SavedStateHandler
@@ -230,6 +232,22 @@ class App extends React.Component <{
 		this.setState({ selectedShifts: shifts })
 		this.topBar.current?.setHasSelectedShifts(shifts)
 		this.savedStateHandler.setShifts(shifts)
+
+		if (this.state.multiShiftMode) {
+			// Check if multi-shift can be disabled safely
+			// if multiple shifts of the same course/type are selected, and
+			// multi-shift is disabled, chaos ensues
+			const shouldDisable = it_contains(
+				combinations2(shifts),
+				([a, b]) => Shift.isSameCourseAndType(a,b)
+			)
+
+			console.log('Should disable?', shouldDisable)
+
+			this.setState({
+				disableMultiShiftModeChange: shouldDisable
+			})
+		}
 	}
 
 	onSelectedShift(shiftName: string, arr: Shift[]): void {
@@ -517,6 +535,7 @@ class App extends React.Component <{
 						darkMode={this.state.darkMode}
 						onChangeDarkMode={this.onChangeDarkMode}
 						multiShiftMode={this.state.multiShiftMode}
+						disableMultiShiftModeChange={this.state.disableMultiShiftModeChange}
 						onChangeMultiShiftMode={this.onChangeMultiShiftMode}
 					>
 					</TopBar>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -641,6 +641,22 @@ class App extends React.Component <{
 											))}
 										</div>
 										<div className={classes.centered as string}>
+											<Tooltip title={i18next.t('multishiftmode-switch') as string}>
+												{/* pay no attention to the dirty styling hacks */}
+												<FormControlLabel
+													className={classes.formLabel as string}
+													label={<AllInclusiveIcon fontSize="small" />}
+													labelPlacement="top"
+													control={
+														<Switch
+															checked={this.state.multiShiftMode}
+															disabled={this.state.inhibitMultiShiftModeChange}
+															onChange={this.onChangeMultiShiftMode}
+															size="small"
+														/>
+													}
+												/>
+											</Tooltip>
 											<Tooltip title={i18next.t('schedule-selected.actions.get-classes') as string}>
 												<IconButton
 													disabled={this.state.selectedShifts.length === 0}
@@ -687,22 +703,6 @@ class App extends React.Component <{
 													component="span">
 													<Icon>delete</Icon>
 												</IconButton>
-											</Tooltip>
-											<Tooltip title={i18next.t('multishiftmode-switch') as string}>
-												{/* pay no attention to the dirty styling hacks */}
-												<FormControlLabel
-													label={<AllInclusiveIcon style={{marginBottom: '-7px'}} />}
-													labelPlacement="top"
-													control={
-														<Switch
-															checked={this.state.multiShiftMode}
-															disabled={this.state.inhibitMultiShiftModeChange}
-															onChange={this.onChangeMultiShiftMode}
-															size="small"
-														/>
-													}
-													style={{margin: '0 6px'}}
-												/>
 											</Tooltip>
 										</div>
 									</CardActions>

--- a/src/components/TopBar/TopBar.tsx
+++ b/src/components/TopBar/TopBar.tsx
@@ -326,7 +326,7 @@ class TopBar extends React.Component <{
 						<Tooltip title={i18next.t('multishiftmode-switch') as string}>
 							<FormControlLabel
 								label={<AllInclusiveIcon/>}
-								control={<Switch disabled={this.props.disableMultiShiftModeChange} onChange={this.onChangeMultiShiftMode} />}
+								control={<Switch checked={this.props.multiShiftMode} disabled={this.props.disableMultiShiftModeChange} onChange={this.onChangeMultiShiftMode} />}
 							/>
 						</Tooltip>
 						<Tooltip title={i18next.t('help-button.tooltip') as string}>

--- a/src/components/TopBar/TopBar.tsx
+++ b/src/components/TopBar/TopBar.tsx
@@ -48,7 +48,11 @@ class TopBar extends React.Component <{
 	onChangeDarkMode: (dark: boolean) => void
     multiShiftMode: boolean
     onChangeMultiShiftMode: (multiShiftMode: boolean) => void
+    disableMultiShiftModeChange: boolean
 }, unknown>{
+	static defaultProps = {
+		disableMultiShiftModeChange: false
+	}
 	state = {
 		degrees: [] as Degree[],
 		availableCourses: [] as Course[],
@@ -322,7 +326,7 @@ class TopBar extends React.Component <{
 						<Tooltip title={i18next.t('multishiftmode-switch') as string}>
 							<FormControlLabel
 								label={<AllInclusiveIcon/>}
-								control={<Switch onChange={this.onChangeMultiShiftMode} />}
+								control={<Switch disabled={this.props.disableMultiShiftModeChange} onChange={this.onChangeMultiShiftMode} />}
 							/>
 						</Tooltip>
 						<Tooltip title={i18next.t('help-button.tooltip') as string}>

--- a/src/components/TopBar/TopBar.tsx
+++ b/src/components/TopBar/TopBar.tsx
@@ -15,6 +15,8 @@ import Toolbar from '@material-ui/core/Toolbar'
 import Tooltip from '@material-ui/core/Tooltip'
 import AppBar from '@material-ui/core/AppBar'
 import IconButton from '@material-ui/core/IconButton'
+import Switch from '@material-ui/core/Switch'
+import FormControlLabel from '@material-ui/core/FormControlLabel'
 import Icon from '@material-ui/core/Icon'
 import Dialog from '@material-ui/core/Dialog'
 import DialogTitle from '@material-ui/core/DialogTitle'
@@ -28,6 +30,7 @@ import Button from '@material-ui/core/Button'
 
 import Brightness2Icon from '@material-ui/icons/Brightness2'
 import Brightness5Icon from '@material-ui/icons/Brightness5'
+import AllInclusiveIcon from '@material-ui/icons/AllInclusiveIcon'
 
 import i18next from 'i18next'
 import Menu from '@material-ui/core/Menu'
@@ -43,6 +46,8 @@ class TopBar extends React.Component <{
 	onChangeLanguage: (language: string, afterChange: () => Promise<void>) => void
 	darkMode: boolean
 	onChangeDarkMode: (dark: boolean) => void
+    multiShiftMode: boolean
+    onChangeMultiShiftMode: (multiShiftMode: boolean) => void
 }, unknown>{
 	state = {
 		degrees: [] as Degree[],
@@ -66,6 +71,7 @@ class TopBar extends React.Component <{
 		this.onSelectedCourse = this.onSelectedCourse.bind(this)
 		this.onLanguageMenuClick = this.onLanguageMenuClick.bind(this)
 		this.onChangeDarkMode = this.onChangeDarkMode.bind(this)
+		this.onChangeMultiShiftMode = this.onChangeMultiShiftMode.bind(this)
 	}
 
 	async componentDidMount(): Promise<void> {
@@ -204,6 +210,10 @@ class TopBar extends React.Component <{
 		this.props.onChangeDarkMode(!this.props.darkMode)
 	}
 
+	onChangeMultiShiftMode(): void {
+		this.props.onChangeMultiShiftMode(!this.props.multiShiftMode)
+	}
+
 	render(): React.ReactNode {
 		const maxTags = 14
 		const courseFilterOptions = createFilterOptions({
@@ -308,6 +318,12 @@ class TopBar extends React.Component <{
 							<IconButton color="inherit" onClick={this.onChangeDarkMode} component="span">
 								{ this.props.darkMode ? <Brightness5Icon/> : <Brightness2Icon/> }
 							</IconButton>
+						</Tooltip>
+						<Tooltip title={i18next.t('multishiftmode-switch') as string}>
+							<FormControlLabel
+								control={<Switch checked={this.props.multiShiftMode} onChange={this.onChangeMultiShiftMode} />}
+								label={<AllInclusiveIcon/>}
+							/>
 						</Tooltip>
 						<Tooltip title={i18next.t('help-button.tooltip') as string}>
 							<IconButton disabled={this.state.helpDialog} color="inherit" onClick={() => {this.setState({helpDialog: true})}} component="span">

--- a/src/components/TopBar/TopBar.tsx
+++ b/src/components/TopBar/TopBar.tsx
@@ -15,8 +15,6 @@ import Toolbar from '@material-ui/core/Toolbar'
 import Tooltip from '@material-ui/core/Tooltip'
 import AppBar from '@material-ui/core/AppBar'
 import IconButton from '@material-ui/core/IconButton'
-import Switch from '@material-ui/core/Switch'
-import FormControlLabel from '@material-ui/core/FormControlLabel'
 import Icon from '@material-ui/core/Icon'
 import Dialog from '@material-ui/core/Dialog'
 import DialogTitle from '@material-ui/core/DialogTitle'
@@ -30,7 +28,6 @@ import Button from '@material-ui/core/Button'
 
 import Brightness2Icon from '@material-ui/icons/Brightness2'
 import Brightness5Icon from '@material-ui/icons/Brightness5'
-import AllInclusiveIcon from '@material-ui/icons/AllInclusive'
 
 import i18next from 'i18next'
 import Menu from '@material-ui/core/Menu'
@@ -46,13 +43,7 @@ class TopBar extends React.Component <{
 	onChangeLanguage: (language: string, afterChange: () => Promise<void>) => void
 	darkMode: boolean
 	onChangeDarkMode: (dark: boolean) => void
-	multiShiftMode: boolean
-	onChangeMultiShiftMode: (multiShiftMode: boolean) => void
-	disableMultiShiftModeChange: boolean
 }, unknown>{
-	static defaultProps = {
-		disableMultiShiftModeChange: false
-	}
 	state = {
 		degrees: [] as Degree[],
 		availableCourses: [] as Course[],
@@ -75,7 +66,6 @@ class TopBar extends React.Component <{
 		this.onSelectedCourse = this.onSelectedCourse.bind(this)
 		this.onLanguageMenuClick = this.onLanguageMenuClick.bind(this)
 		this.onChangeDarkMode = this.onChangeDarkMode.bind(this)
-		this.onChangeMultiShiftMode = this.onChangeMultiShiftMode.bind(this)
 	}
 
 	async componentDidMount(): Promise<void> {
@@ -101,7 +91,7 @@ class TopBar extends React.Component <{
 		if (degrees.length > 0) {
 			let degreeCourses: Course[] = []
 			for (const degree of degrees) {
-				const tempCourses = await API.getCourses(degree) 
+				const tempCourses = await API.getCourses(degree)
 				if (tempCourses === null) {
 					// TODO: Test when this cannot be obtained
 					this.props.showAlert(i18next.t('alert.cannot-obtain-courses'), 'error')
@@ -134,7 +124,7 @@ class TopBar extends React.Component <{
 		})
 	}
 
-	//FIXME: Available courses not updating when a course from another degree is removed 
+	//FIXME: Available courses not updating when a course from another degree is removed
 	private async onSelectedCourse(selectedCourses: Course[]): Promise<void> {
 		this.props.onSelectedCourse(selectedCourses)
 	}
@@ -152,7 +142,7 @@ class TopBar extends React.Component <{
 
 	setSelectedCourses(selectedCourses: CourseUpdates): void {
 		// FIXME: Maybe not use toUnique?
-		const availableCourses = 
+		const availableCourses =
 			Comparables.toUnique(this.state.availableCourses.concat(selectedCourses.courses)) as Course[]
 		this.setState({
 			selectedCourses,
@@ -212,10 +202,6 @@ class TopBar extends React.Component <{
 
 	onChangeDarkMode(): void {
 		this.props.onChangeDarkMode(!this.props.darkMode)
-	}
-
-	onChangeMultiShiftMode(event: React.ChangeEvent<HTMLInputElement>, value: boolean): void {
-		this.props.onChangeMultiShiftMode(value)
 	}
 
 	render(): React.ReactNode {
@@ -323,12 +309,6 @@ class TopBar extends React.Component <{
 								{ this.props.darkMode ? <Brightness5Icon/> : <Brightness2Icon/> }
 							</IconButton>
 						</Tooltip>
-						<Tooltip title={i18next.t('multishiftmode-switch') as string}>
-							<FormControlLabel
-								label={<AllInclusiveIcon/>}
-								control={<Switch checked={this.props.multiShiftMode} disabled={this.props.disableMultiShiftModeChange} onChange={this.onChangeMultiShiftMode} />}
-							/>
-						</Tooltip>
 						<Tooltip title={i18next.t('help-button.tooltip') as string}>
 							<IconButton disabled={this.state.helpDialog} color="inherit" onClick={() => {this.setState({helpDialog: true})}} component="span">
 								<Icon>help</Icon>
@@ -359,7 +339,7 @@ class TopBar extends React.Component <{
 								// className={styles.semesterSelector}
 								autoWidth={true}
 							>
-								{staticData.terms.map( (s) => 
+								{staticData.terms.map( (s) =>
 									<MenuItem key={s.id} value={s.id}>{s.term} {s.semester}{i18next.t('settings-dialog.select.value', { count: s.semester }) as string}
 									</MenuItem>
 								)}

--- a/src/components/TopBar/TopBar.tsx
+++ b/src/components/TopBar/TopBar.tsx
@@ -46,9 +46,9 @@ class TopBar extends React.Component <{
 	onChangeLanguage: (language: string, afterChange: () => Promise<void>) => void
 	darkMode: boolean
 	onChangeDarkMode: (dark: boolean) => void
-    multiShiftMode: boolean
-    onChangeMultiShiftMode: (multiShiftMode: boolean) => void
-    disableMultiShiftModeChange: boolean
+	multiShiftMode: boolean
+	onChangeMultiShiftMode: (multiShiftMode: boolean) => void
+	disableMultiShiftModeChange: boolean
 }, unknown>{
 	static defaultProps = {
 		disableMultiShiftModeChange: false

--- a/src/components/TopBar/TopBar.tsx
+++ b/src/components/TopBar/TopBar.tsx
@@ -30,7 +30,7 @@ import Button from '@material-ui/core/Button'
 
 import Brightness2Icon from '@material-ui/icons/Brightness2'
 import Brightness5Icon from '@material-ui/icons/Brightness5'
-import AllInclusiveIcon from '@material-ui/icons/AllInclusiveIcon'
+import AllInclusiveIcon from '@material-ui/icons/AllInclusive'
 
 import i18next from 'i18next'
 import Menu from '@material-ui/core/Menu'
@@ -210,8 +210,8 @@ class TopBar extends React.Component <{
 		this.props.onChangeDarkMode(!this.props.darkMode)
 	}
 
-	onChangeMultiShiftMode(): void {
-		this.props.onChangeMultiShiftMode(!this.props.multiShiftMode)
+	onChangeMultiShiftMode(event: React.ChangeEvent<HTMLInputElement>, value: boolean): void {
+		this.props.onChangeMultiShiftMode(value)
 	}
 
 	render(): React.ReactNode {
@@ -321,8 +321,8 @@ class TopBar extends React.Component <{
 						</Tooltip>
 						<Tooltip title={i18next.t('multishiftmode-switch') as string}>
 							<FormControlLabel
-								control={<Switch checked={this.props.multiShiftMode} onChange={this.onChangeMultiShiftMode} />}
 								label={<AllInclusiveIcon/>}
+								control={<Switch onChange={this.onChangeMultiShiftMode} />}
 							/>
 						</Tooltip>
 						<Tooltip title={i18next.t('help-button.tooltip') as string}>

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -17,6 +17,7 @@
 		"dark": "Set to light mode",
 		"light": "Set to dark mode"
 	},
+	"multishiftmode-switch": "Allow choosing multiple shifts of the same kind/course",
 	"help-button": {
 		"tooltip": "Help"
 	},

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -17,7 +17,7 @@
 		"dark": "Mudar para o modo claro",
 		"light": "Mudar para o modo escuro"
 	},
-	"multishiftmode-button": "Permitir escolher vários turnos do mesmo tipo/cadeira",
+	"multishiftmode-switch": "Permitir escolher vários turnos do mesmo tipo/cadeira",
 	"help-button": {
 		"tooltip": "Ajuda"
 	},

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -17,6 +17,7 @@
 		"dark": "Mudar para o modo claro",
 		"light": "Mudar para o modo escuro"
 	},
+	"multishiftmode-button": "Permitir escolher vários turnos do mesmo tipo/cadeira",
 	"help-button": {
 		"tooltip": "Ajuda"
 	},

--- a/src/styles/styles.tsx
+++ b/src/styles/styles.tsx
@@ -43,6 +43,12 @@ export const APP_STYLES = (theme: any) => ({
 		webkitUserSelect: 'text' as const,
 		oUserSelected: 'text' as const
 	},
+	formLabel: {
+		margin: 0,
+		'& .MuiTypography-root': {
+			lineHeight: 0.5
+		}
+	},
 	footer: {
 		bottom: '0px',
 		top: 'auto',

--- a/src/utils/itertools.ts
+++ b/src/utils/itertools.ts
@@ -1,0 +1,32 @@
+export function* combinations2<T>(arr: T[]): Generator<[T, T]> {
+	for (let i = 0; i < arr.length; i++) {
+		for (let j = i+1; j < arr.length; j++) {
+			yield [arr[i], arr[j]]
+		}
+	}
+}
+
+export function* it_filter<T>(it: Iterable<T>, pred: (el: T) => boolean): Generator<T> {
+	for (const el of it) {
+		if (pred(el)) {
+			yield el
+		}
+	}
+}
+
+export function it_first<T>(it: Iterable<T>): T|undefined {
+	const head = it[Symbol.iterator]().next()
+	if (head.done) {
+		return undefined
+	} else {
+		return head.value
+	}
+}
+
+export function it_find<T>(it: Iterable<T>, pred: (el: T) => boolean): T|undefined {
+	return it_first(it_filter(it, pred))
+}
+
+export function it_contains<T>(it: Iterable<T>, pred: (el: T) => boolean): boolean {
+	return it_find(it, pred) !== undefined
+}

--- a/src/utils/saved-state-handler.tsx
+++ b/src/utils/saved-state-handler.tsx
@@ -13,6 +13,7 @@ export default class SavedStateHandler {
 	static LANGUAGE = 'language'
 	static WARNING = 'warning'
 	static COLORS = 'colors'
+	static IS_MULTISHIFT = 'ismulti'
 
 	static MAX_AGE_NORMAL = 60*60*24*31*3 // 3 months
 	static MAX_AGE_SMALL = 60*60*24 // 1 day
@@ -24,6 +25,7 @@ export default class SavedStateHandler {
 	private shifts: string
 	private degrees: string
 	private colors: Record<string, string>
+	private multiShiftMode: boolean
 	private cookies = new Cookies()
 
 	constructor(urlParams: Record<string, string>) {
@@ -32,11 +34,12 @@ export default class SavedStateHandler {
 		this.degrees = urlParams[SavedStateHandler.DEGREES] ?? this.getLocalStorage(SavedStateHandler.DEGREES) ??
 			this.getCookie(SavedStateHandler.DEGREES)
 		this.colors = (this.getLocalStorage(SavedStateHandler.COLORS, true) ?? {}) as Record<string, string>
+		this.multiShiftMode = (urlParams[SavedStateHandler.IS_MULTISHIFT] ?? this.getLocalStorage(SavedStateHandler.IS_MULTISHIFT)) === 'true'
 	}
 
 	// CLASS METHODS
 	// Updates user URL to use or not the state
-	static async changeUrl(toState: boolean, selectedShifts: Shift[]): Promise<void> {
+	static async changeUrl(toState: boolean, selectedShifts: Shift[], multiShiftMode: boolean): Promise<void> {
 		const title: string = document.title
 		let path = API.PATH_PREFIX + '/'
 		if (toState) {
@@ -45,6 +48,8 @@ export default class SavedStateHandler {
 
 			const degrees = getDegreesAcronyms(selectedShifts)
 			if (degrees !== '') path += `&${this.DEGREES}=${degrees}`
+
+			if (multiShiftMode) path += `&${this.IS_MULTISHIFT}=true`
 		}
 
 		if (window.history.replaceState) {
@@ -98,6 +103,15 @@ export default class SavedStateHandler {
 		}, { availableShifts: [], selectedShifts: [] } as ShiftState)
 
 		return [courseUpdate, state]
+	}
+
+	setMultiShiftMode(multiShiftMode: boolean): void {
+		this.multiShiftMode = true
+		this.setLocalStorage(SavedStateHandler.IS_MULTISHIFT, multiShiftMode.toString())
+	}
+
+	getMultiShiftMode(): boolean {
+		return this.multiShiftMode
 	}
 
 	getDarkMode(): boolean | null {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2015",
     "lib": [
       "dom",
       "dom.iterable",


### PR DESCRIPTION
Makes this great for teachers too!

When it's enabled, it can only be disabled when no two (or more) shifts of the same course/type are selected.
This is done to prevent weird behavior when manipulating those shifts: when trying to "replace" one of them, the app would just delete one of the N selected seemingly at random.

Supports persistence to localStorage/cookies, and sharing via URL (safeguard from above also works in these conditions).

Not too happy with the UI, but it does convey all states of the feature (on and can be disabled/on but cannot be disabled/off). I originally envisioned the switch below the icon, but the margins were too big and I had no idea how to change them.